### PR TITLE
Logout

### DIFF
--- a/backend/internal/auth/sessionmanager.go
+++ b/backend/internal/auth/sessionmanager.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -24,13 +23,7 @@ var (
 // Package specific contextKey type
 type contextKey string
 
-// newContextKey generates a key for storing and accessing values in context.Context.
-// It has a package specific prefix plus additional entropy for added safety, in order
-// to prevent key collisions with other packages.
-func newContextKey() (contextKey, error) {
-	s, err := generateRandomString(8)
-	return contextKey(fmt.Sprintf("teleport-interview-auth.%v", s)), err
-}
+var theContextKey = contextKey("teleport-interview-auth")
 
 // Session is an individual user's session
 type Session struct {
@@ -52,12 +45,10 @@ type SessionManager struct {
 
 // NewSessionManager creates a new *SessionManager
 func NewSessionManager(timeout time.Duration) *SessionManager {
-	ck, err := newContextKey()
-	if err != nil {
-		// Fail here, this is an operating system error plus the app cannot function without contextKey
-		panic(err)
-	}
-	return &SessionManager{store: make(map[SessionID]Session), timeout: timeout, contextKey: ck}
+	return &SessionManager{
+		store:      make(map[SessionID]Session),
+		timeout:    timeout,
+		contextKey: theContextKey}
 }
 
 // CreateSession creates a new session in the SessionManager's store, indexed by a

--- a/backend/internal/handlers/logout.go
+++ b/backend/internal/handlers/logout.go
@@ -17,16 +17,11 @@ func NewLogoutHandler(sm *auth.SessionManager) *LogoutHandler {
 	return &LogoutHandler{sm}
 }
 
-// GetSessionManager returns the global SessionManager
-func (lh *LogoutHandler) GetSessionManager() *auth.SessionManager {
-	return lh.sm
-}
-
-func (lh *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, s auth.Session) {
+func (lh *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Couldn't find session. Log that this happened and return a 204
 	// to alert the client to behave as if the user is logged out.
-	if !lh.sm.DeleteSession(s.SessionID) {
-		log.Printf("logout attempted but could not find session %v", s.SessionID)
+	if !lh.sm.DeleteSession(r.Context()) {
+		log.Println("logout attempted but could not find session")
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/handlers/logout.go
+++ b/backend/internal/handlers/logout.go
@@ -18,9 +18,15 @@ func NewLogoutHandler(sm *auth.SessionManager) *LogoutHandler {
 }
 
 func (lh *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	session, err := lh.sm.FromContext(r.Context())
+	if err != nil {
+		log.Println(err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 	// Couldn't find session. Log that this happened and return a 204
 	// to alert the client to behave as if the user is logged out.
-	if !lh.sm.DeleteSession(r.Context()) {
+	if !lh.sm.DeleteSession(session.SessionID) {
 		log.Println("logout attempted but could not find session")
 	}
 

--- a/backend/internal/handlers/utils.go
+++ b/backend/internal/handlers/utils.go
@@ -7,8 +7,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-
-	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
 )
 
 type malformedRequest struct {
@@ -62,67 +60,4 @@ func handleJSONdecodeError(w http.ResponseWriter, err error) {
 		log.Println(err)
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
-}
-
-var (
-	errAuthHeaderNotFound     = errors.New("Authorization header expected but not found")
-	errAuthHeaderNotFormatted = errors.New("Authorization header was improperly formatted")
-)
-
-// Helper function to retreive a token sent in standard "Bearer" format from a request
-// (https://tools.ietf.org/html/rfc6750#page-5). If the request doesn't contain an Authorization
-// header or the Authorization header is improperly formatted, getBearerToken returns "".
-// Handlers generally shouldn't call this function, and should instead call getSessionID or
-// getApiKey (TODO) to specify which type of token they are expecting.
-func getBearerToken(r *http.Request) (string, error) {
-	reqToken := r.Header.Get("Authorization")
-	if reqToken == "" {
-		// Request did not contain an Authorization header
-		return "", errAuthHeaderNotFound
-	}
-	splitToken := strings.Split(reqToken, "Bearer ")
-	if len(splitToken) == 1 {
-		// Split failed, request may have been improperly formatted
-		return "", errAuthHeaderNotFormatted
-	}
-	return splitToken[1], nil
-}
-
-func getSessionID(r *http.Request) (auth.SessionID, error) {
-	s, err := getBearerToken(r)
-	return auth.SessionID(s), err
-}
-
-// handlerWithSession behaves like an ordinary http.Hander (https://golang.org/pkg/net/http/#Handler)
-// but expects an auth.Session
-type handlerWithSession interface {
-	ServeHTTP(w http.ResponseWriter, r *http.Request, session auth.Session)
-	GetSessionManager() *auth.SessionManager
-}
-
-// WithSessionAuth is middlewear for protecting HandlerWithSession's with sessionID auth
-func WithSessionAuth(hws handlerWithSession) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Get sessionID from the request
-		sessionID, err := getSessionID(r)
-		if err != nil {
-			// Could not get sessionID, return 401
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-			return
-		}
-
-		// Attempt to get the corresponding session from the SessionManager
-		sm := hws.GetSessionManager()
-		session, err := sm.GetSession(sessionID)
-		if err != nil {
-			// Session does not exist or timed out
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-			return
-		}
-
-		// User is authorized, call the HandlerWithSession
-		hws.ServeHTTP(w, r, session)
-	})
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -42,7 +42,7 @@ func New(cfg Config) (*Server, error) {
 	srv.router.Handle("/api/login", loginHandler).Methods("POST")
 
 	logoutHandler := handlers.NewLogoutHandler(srv.sm)
-	srv.router.Handle("/api/logout", handlers.WithSessionAuth(logoutHandler)).Methods("DELETE")
+	srv.router.Handle("/api/logout", srv.sm.WithSessionAuth(logoutHandler)).Methods("DELETE")
 
 	// NOTE: It's important that this handler be registered after the other handlers, or else
 	// all routes return a 404 (at least in development). TODO: figure out why this is the case.


### PR DESCRIPTION
Changes `WithSessionAuth` to a middlewear that checks for the appropriate authorization header and checks that a valid `Session` exists (returning 401's if either doesn't check out), and then passes the `Session` as a value into the request's `context.Context`, allowing wrapped handlers to interact with Sessions via methods that pass in their` r.Context()` (currently onely `sm.DeleteSession` does this, but this should work generally).

Also addresses @awly's comments from prematurely-merged https://github.com/ibeckermayer/teleport-interview/pull/5