### PR TITLE
Metrics POST endpoint

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -70,9 +70,9 @@ Note: passwords will be salted and hashed using the [bcrypt](https://godoc.org/g
 | ------- | ---------- | --------- | ---------- | ---------- |
 | user_id | account_id | is_active | created_at | updated_at |
 
-| logins     |         |           |
-| ---------- | ------- | --------- |
-| account_id | user_id | timestamp |
+| metric    |            |         |           |
+| --------- | ---------- | ------- | --------- |
+| metric_id | account_id | user_id | timestamp |
 
 | apikey   |            |
 | -------- | ---------- |

--- a/backend/internal/auth/genkey.go
+++ b/backend/internal/auth/genkey.go
@@ -42,3 +42,13 @@ func newSessionID() (SessionID, error) {
 	s, err := generateRandomString(32)
 	return SessionID(s), err
 }
+
+// Key is a 32 byte, base64 encoded, cryptographically secure random string
+type Key string
+
+// newKey creates a new API Key. It will return an error if the system's secure random
+// number generator fails to function correctly, in which case the caller should not continue.
+func newKey() (Key, error) {
+	s, err := generateRandomString(32)
+	return Key(s), err
+}

--- a/backend/internal/auth/genkey.go
+++ b/backend/internal/auth/genkey.go
@@ -46,9 +46,9 @@ func newSessionID() (SessionID, error) {
 // Key is a 32 byte, base64 encoded, cryptographically secure random string
 type Key string
 
-// newKey creates a new API Key. It will return an error if the system's secure random
+// NewKey creates a new API Key. It will return an error if the system's secure random
 // number generator fails to function correctly, in which case the caller should not continue.
-func newKey() (Key, error) {
+func NewKey() (Key, error) {
 	s, err := generateRandomString(32)
 	return Key(s), err
 }

--- a/backend/internal/auth/password.go
+++ b/backend/internal/auth/password.go
@@ -7,16 +7,16 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// HashAPIkey returns a stringified (64 bytes) sha256 checksum of a Key.
+// HashKey returns a stringified (64 bytes) sha256 checksum of a Key.
 // This is sufficient for securely storing Key's in the database,
 // see reputable StackExchange answer: https://security.stackexchange.com/a/180364
-func HashAPIkey(apikey Key) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(apikey)))
+func HashKey(key Key) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(key)))
 }
 
-// CheckAPIkeyHash checks whether a plaintext Key is represented by a hash
-func CheckAPIkeyHash(apikey Key, hash string) bool {
-	return HashAPIkey(apikey) == hash
+// CheckKeyHash checks whether a plaintext Key is represented by a hash
+func CheckKeyHash(key Key, hash string) bool {
+	return HashKey(key) == hash
 }
 
 // HashPassword returns a stringified password hash

--- a/backend/internal/auth/password.go
+++ b/backend/internal/auth/password.go
@@ -1,6 +1,23 @@
 package auth
 
-import "golang.org/x/crypto/bcrypt"
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// HashAPIkey returns a stringified (64 bytes) sha256 checksum of a Key.
+// This is sufficient for securely storing Key's in the database,
+// see reputable StackExchange answer: https://security.stackexchange.com/a/180364
+func HashAPIkey(apikey Key) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(apikey)))
+}
+
+// CheckAPIkeyHash checks whether a plaintext Key is represented by a hash
+func CheckAPIkeyHash(apikey Key, hash string) bool {
+	return HashAPIkey(apikey) == hash
+}
 
 // HashPassword returns a stringified password hash
 func HashPassword(password string) (string, error) {

--- a/backend/internal/auth/sessionmanager.go
+++ b/backend/internal/auth/sessionmanager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
 )
 
 var (
@@ -165,7 +166,7 @@ func (sm *SessionManager) WithSessionAuth(next http.Handler) http.Handler {
 		if err != nil {
 			// Could not get sessionID, return 401
 			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			util.ErrorJSON(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
 
@@ -173,7 +174,7 @@ func (sm *SessionManager) WithSessionAuth(next http.Handler) http.Handler {
 		if err != nil {
 			// Session does not exist or timed out
 			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			util.ErrorJSON(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
 

--- a/backend/internal/auth/sessionmanager.go
+++ b/backend/internal/auth/sessionmanager.go
@@ -137,12 +137,12 @@ var (
 	errAuthHeaderNotFormatted = errors.New("Authorization header was improperly formatted")
 )
 
-// Helper function to retreive a token sent in standard "Bearer" format from a request
+// GetBearerToken is a helper function to retreive a token sent in standard "Bearer" format from a request
 // (https://tools.ietf.org/html/rfc6750#page-5). If the request doesn't contain an Authorization
 // header or the Authorization header is improperly formatted, getBearerToken returns "".
 // Handlers generally shouldn't call this function, and should instead call getSessionID or
 // getApiKey (TODO) to specify which type of token they are expecting.
-func getBearerToken(r *http.Request) (string, error) {
+func GetBearerToken(r *http.Request) (string, error) {
 	reqToken := r.Header.Get("Authorization")
 	if reqToken == "" {
 		// Request did not contain an Authorization header
@@ -158,7 +158,7 @@ func getBearerToken(r *http.Request) (string, error) {
 }
 
 func getSessionID(r *http.Request) (SessionID, error) {
-	s, err := getBearerToken(r)
+	s, err := GetBearerToken(r)
 	return SessionID(s), err
 }
 

--- a/backend/internal/database/account.go
+++ b/backend/internal/database/account.go
@@ -12,6 +12,13 @@ func (db *Database) insertAccount(a *model.Account) error {
 	return err
 }
 
+// GetAccount retrieves an Account from the database by accountID
+func (db *Database) GetAccount(accountID string) (model.Account, error) {
+	a := model.Account{}
+	err := db.db.Get(&a, "SELECT * FROM account WHERE account_id=$1", accountID)
+	return a, err
+}
+
 // GetAccountByEmail retrieves an Account from the database by email address
 func (db *Database) GetAccountByEmail(email string) (model.Account, error) {
 	a := model.Account{}

--- a/backend/internal/database/account.go
+++ b/backend/internal/database/account.go
@@ -7,13 +7,13 @@ import (
 	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
 )
 
-func (db *Database) insert(a *model.Account) error {
+func (db *Database) insertAccount(a *model.Account) error {
 	_, err := db.db.NamedExec("INSERT INTO account (account_id, plan, email, password_hash, created_at, updated_at) VALUES (:account_id, :plan, :email, :password_hash, :created_at, :updated_at)", a)
 	return err
 }
 
-// GetAccount retrieves an Account from the database by email address
-func (db *Database) GetAccount(email string) (model.Account, error) {
+// GetAccountByEmail retrieves an Account from the database by email address
+func (db *Database) GetAccountByEmail(email string) (model.Account, error) {
 	a := model.Account{}
 	err := db.db.Get(&a, "SELECT * FROM account WHERE email=$1", email)
 	return a, err
@@ -33,6 +33,6 @@ func (db *Database) CreateAccount(accountID, email, password string) error {
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
 	}
-	err = db.insert(account)
+	err = db.insertAccount(account)
 	return err
 }

--- a/backend/internal/database/apikey.go
+++ b/backend/internal/database/apikey.go
@@ -1,0 +1,26 @@
+package database
+
+import (
+	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
+)
+
+func (db *Database) insertAPIkey(apikey *model.APIkey) error {
+	_, err := db.db.NamedExec("INSERT INTO apikey (key_hash, account_id) VALUES (:key_hash, :account_id)", apikey)
+	return err
+}
+
+// GetAPIkey gets an apikey from the database by accountID
+func (db *Database) GetAPIkey(accountID string) (model.APIkey, error) {
+	k := model.APIkey{}
+	err := db.db.Get(&k, "SELECT * FROM apikey WHERE account_id=$1", accountID)
+	return k, err
+}
+
+// CreateAPIkey creates a new apikey entry
+// TODO: could check that accouuntID exists in account table
+func (db *Database) CreateAPIkey(key auth.Key, accountID string) error {
+	keyHash := auth.HashKey(key)
+	apikey := &model.APIkey{KeyHash: keyHash, AccountID: accountID}
+	return db.insertAPIkey(apikey)
+}

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -52,12 +52,20 @@ func New(cfg Config) (*Database, error) {
 }
 
 func (db *Database) init() error {
-
+	// Create all tables if they don't exist
 	if _, err := db.db.Exec(model.AccountTableSQL); err != nil {
 		return err
 	}
 
 	if _, err := db.db.Exec(model.APIkeyTableSQL); err != nil {
+		return err
+	}
+
+	if _, err := db.db.Exec(model.MetricTableSQL); err != nil {
+		return err
+	}
+
+	if _, err := db.db.Exec(model.UserTableSQL); err != nil {
 		return err
 	}
 

--- a/backend/internal/database/metric.go
+++ b/backend/internal/database/metric.go
@@ -1,0 +1,26 @@
+package database
+
+import (
+	"time"
+
+	"github.com/pborman/uuid"
+
+	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
+)
+
+func (db *Database) insertMetric(m *model.Metric) error {
+	_, err := db.db.NamedExec("INSERT INTO metric (metric_id, account_id, user_id, timestamp) VALUES (:metric_id, :account_id, :user_id, :timestamp)", m)
+	return err
+}
+
+// CreateMetric adds a new metric to the "metric" table in the database
+func (db *Database) CreateMetric(accountID, userID string, timestamp time.Time) error {
+	metric := &model.Metric{
+		MetricID:  uuid.New(),
+		AccountID: accountID,
+		UserID:    userID,
+		Timestamp: timestamp,
+	}
+
+	return db.insertMetric(metric)
+}

--- a/backend/internal/database/user.go
+++ b/backend/internal/database/user.go
@@ -1,0 +1,58 @@
+package database
+
+import (
+	"errors"
+	"time"
+
+	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
+)
+
+var (
+	// ErrOrphanedUser is returned if caller attempts to create a user associated with an account_id that DNE.
+	ErrOrphanedUser = errors.New("attempted to create an orphaned user")
+)
+
+// GetUser retrieves a user from the database by user_id. Returns an error if user DNE.
+func (db *Database) GetUser(userID string) (model.User, error) {
+	u := model.User{}
+	err := db.db.Get(&u, "SELECT * FROM user WHERE user_id=$1", userID)
+	return u, err
+}
+
+// CountUsers counts how many users are associated with the accountID
+func (db *Database) CountUsers(accountID string) (int, error) {
+	var c int
+	err := db.db.Get(&c, "SELECT count(*) FROM user WHERE account_id=$1", accountID)
+	return c, err
+}
+
+// CreateUser creates a new user with userID associated with accountID. Determines
+// whether the new User is active based on if the associated account has reached the
+// user limit on its current plan.
+func (db *Database) CreateUser(userID, accountID string) error {
+	account, err := db.GetAccount(accountID)
+	if err != nil {
+		// Could not find account, don't create orphaned user
+		return err
+	}
+
+	count, err := db.CountUsers(accountID)
+	if err != nil {
+		return err
+	}
+
+	user := &model.User{
+		UserID:    userID,
+		AccountID: accountID,
+		IsActive:  count+1 <= model.PlanMaxUsers[account.Plan],
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	return db.insertUser(user)
+}
+
+func (db *Database) insertUser(u *model.User) error {
+	_, err := db.db.NamedExec("INSERT INTO user (user_id, account_id, is_active, created_at, updated_at) VALUES (:user_id, :account_id, :is_active, :created_at, :updated_at)", u)
+	return err
+}

--- a/backend/internal/handlers/login.go
+++ b/backend/internal/handlers/login.go
@@ -42,7 +42,7 @@ func (lh *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	account, err := lh.db.GetAccount(body.Email)
+	account, err := lh.db.GetAccountByEmail(body.Email)
 
 	// Handle errors from attempting to retrieve the account from the database
 	if err != nil {

--- a/backend/internal/handlers/login.go
+++ b/backend/internal/handlers/login.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
 	"github.com/ibeckermayer/teleport-interview/backend/internal/database"
 	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
 )
 
 // LoginHandler handles calls to "/api/login". Implements http.Handler
@@ -36,9 +37,9 @@ type loginResponseBody struct {
 func (lh *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var body loginRequestBody
 
-	err := decodeJSONBody(w, r, &body)
+	err := util.DecodeJSONBody(w, r, &body)
 	if err != nil {
-		handleJSONdecodeError(w, err)
+		util.HandleJSONdecodeError(w, err)
 		return
 	}
 
@@ -49,17 +50,17 @@ func (lh *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		if err == sql.ErrNoRows {
 			// No record with the given email address exists
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			util.ErrorJSON(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return
 		}
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 
 	// Account retrieved, check password
 	if !auth.CheckPasswordHash(body.Password, account.PasswordHash) {
 		// Invalid password, unauthorized
-		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		util.ErrorJSON(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		return
 	}
 
@@ -67,7 +68,7 @@ func (lh *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	session, err := lh.sm.CreateSession(account)
 	if err != nil {
 		log.Println(err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 

--- a/backend/internal/handlers/logout.go
+++ b/backend/internal/handlers/logout.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
 )
 
 // LogoutHandler handles calls to "/api/logout". Implements HandlerWithSession
@@ -21,7 +22,7 @@ func (lh *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	session, err := lh.sm.FromContext(r.Context())
 	if err != nil {
 		log.Println(err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 	// Couldn't find session. Log that this happened and return a 204

--- a/backend/internal/handlers/metric.go
+++ b/backend/internal/handlers/metric.go
@@ -25,8 +25,6 @@ type metricsPostRequestBody struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-// type metricsPostResponseBody struct{}
-
 // Handles "/api/metrics" POST requests. Should be wrapped with WithAPIkeyAuth middlewear
 func (mph *MetricsPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var body metricsPostRequestBody

--- a/backend/internal/handlers/metric.go
+++ b/backend/internal/handlers/metric.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/ibeckermayer/teleport-interview/backend/internal/database"
+)
+
+// MetricsPostHandler handles calls to "api/metrics"
+type MetricsPostHandler struct {
+	db *database.Database
+}
+
+// NewMetricsPostHandler creates a new MetricsHandler
+func NewMetricsPostHandler(db *database.Database) *MetricsPostHandler {
+	return &MetricsPostHandler{db}
+}
+
+type metricsPostRequestBody struct {
+	AccountID string    `json:"account_id"`
+	UserID    string    `json:"user_id"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// Handles "/api/metrics" POST requests. Should be wrapped with WithAPIkeyAuth middlewear
+func (mph *MetricsPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var body metricsPostRequestBody
+
+	// Decode json
+	err := decodeJSONBody(w, r, &body)
+	if err != nil {
+		handleJSONdecodeError(w, err)
+		return
+	}
+
+	// Save the metric to the database
+	if err := mph.db.CreateMetric(body.AccountID, body.UserID, body.Timestamp); err != nil {
+		log.Println(err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Check if this user exists
+
+	// If user DNE, save new user to the database
+}

--- a/backend/internal/handlers/utils.go
+++ b/backend/internal/handlers/utils.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 )
 
+// BodyMaxSize is the maximum size of a json body
+var BodyMaxSize int64 = 1048576 // 1MB
+
 type malformedRequest struct {
 	status int    // HTTP status
 	logMsg string // Detailed message for logging, not to be returned to clients
@@ -29,7 +32,7 @@ func decodeJSONBody(w http.ResponseWriter, r *http.Request, dst interface{}) err
 		}
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, 1048576) // 1MB
+	r.Body = http.MaxBytesReader(w, r.Body, BodyMaxSize)
 
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()

--- a/backend/internal/model/account.go
+++ b/backend/internal/model/account.go
@@ -14,6 +14,12 @@ const (
 	ENTERPRISE = Plan("ENTERPRISE")
 )
 
+// PlanMaxUsers specifies the maximum number of users for each plan
+var PlanMaxUsers = map[Plan]int{
+	FREE:       100,
+	ENTERPRISE: 1000,
+}
+
 // AccountTableSQL is the SQL statement for creating a table corresponding to the Account model
 var AccountTableSQL = `CREATE TABLE IF NOT EXISTS account (
 	account_id CHARACTER(36) PRIMARY KEY,

--- a/backend/internal/model/apikey.go
+++ b/backend/internal/model/apikey.go
@@ -1,0 +1,6 @@
+package model
+
+// APIkeyTableSQL is the SQL statement for creating a table corresponding to the APIkey model
+var APIkeyTableSQL = `CREATE TABLE IF NOT EXISTS apikey (
+	key_hash CHARACTER(64) PRIMARY KEY,
+	account_id CHARACTER(36));`

--- a/backend/internal/model/apikey.go
+++ b/backend/internal/model/apikey.go
@@ -4,3 +4,9 @@ package model
 var APIkeyTableSQL = `CREATE TABLE IF NOT EXISTS apikey (
 	key_hash CHARACTER(64) PRIMARY KEY,
 	account_id CHARACTER(36));`
+
+// APIkey represents a row in the "apikey" table
+type APIkey struct {
+	KeyHash   string `db:"key_hash"`
+	AccountID string `db:"account_id"`
+}

--- a/backend/internal/model/metric.go
+++ b/backend/internal/model/metric.go
@@ -1,0 +1,19 @@
+package model
+
+import "time"
+
+// MetricTableSQL is the SQL statement for createing a table corresponding to the Metric model
+var MetricTableSQL = `CREATE TABLE IF NOT EXISTS metric (
+	metric_id CHARACTER(36) PRIMARY KEY,
+	account_id CHARACTER(36),
+	user_id CHARACTER(36),
+	timestamp DATETIME
+);`
+
+// Metric represents a row in the "metric" table
+type Metric struct {
+	MetricID  string    `db:"metric_id"`
+	AccountID string    `db:"account_id"`
+	UserID    string    `db:"user_id"`
+	Timestamp time.Time `db:"timestamp"`
+}

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -1,0 +1,21 @@
+package model
+
+import "time"
+
+// UserTableSQL is the SQL statement for createing a table corresponding to the User model
+var UserTableSQL = `CREATE TABLE IF NOT EXISTS metric (
+	user_id CHARACTER(36) PRIMARY KEY,
+	account_id CHARACTER(36),
+	is_active INTEGER,
+	created_at DATETIME,
+	updated_at DATETIME
+);`
+
+// User represents a row in the "user" table
+type User struct {
+	UserID    string    `db:"user_id"`
+	AccountID string    `db:"account_id"`
+	IsActive  bool      `db:"is_active"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -3,7 +3,7 @@ package model
 import "time"
 
 // UserTableSQL is the SQL statement for createing a table corresponding to the User model
-var UserTableSQL = `CREATE TABLE IF NOT EXISTS metric (
+var UserTableSQL = `CREATE TABLE IF NOT EXISTS user (
 	user_id CHARACTER(36) PRIMARY KEY,
 	account_id CHARACTER(36),
 	is_active INTEGER,

--- a/backend/internal/server/middlewear.go
+++ b/backend/internal/server/middlewear.go
@@ -128,9 +128,25 @@ func (srv *Server) WithAPIkeyAuth(next http.Handler) http.Handler {
 func WithAPIHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		w.Header().Add("Strict-Transport-Security", "max-age=6307200; includeSubDomains")
+		w.Header().Add("Strict-Transport-Security", "max-age=631138519; includeSubDomains")
 		w.Header().Add("X-Content-Type-Options", "nosniff")
 		w.Header().Add("X-Permitted-Cross-Domain-Policies", "none")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// WithHTMLHeaders adds security headers for serving an html page / spa app.
+// Based on https://github.com/github/secure_headers
+func WithHTMLHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// TODO: need to figure out Content-Type header that will work with X-Content-Type-Options: nosniff
+		// TODO: This Content-Security-Policy may block some css that we need (untested)
+		w.Header().Add("Content-Security-Policy", "default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'")
+		w.Header().Add("Strict-Transport-Security", "max-age=631138519; includeSubDomains")
+		w.Header().Add("X-Download-Options", "noopen")
+		w.Header().Add("X-Frame-Options", "sameorigin")
+		w.Header().Add("X-Permitted-Cross-Domain-Policies", "none")
+		w.Header().Add("X-Xss-Protection", "1; mode=block")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/backend/internal/server/middlewear.go
+++ b/backend/internal/server/middlewear.go
@@ -7,9 +7,14 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
-	"github.com/ibeckermayer/teleport-interview/backend/internal/handlers"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
+)
+
+var (
+	errBadAccountID = errors.New("account ID improperly formatted")
 )
 
 func getAPIkey(r *http.Request) (auth.Key, error) {
@@ -26,17 +31,17 @@ func getAccountIDfromBody(w http.ResponseWriter, r *http.Request) (string, error
 	if r.Body == nil {
 		err := errors.New("request body was nil")
 		log.Println(err)
-		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
+		util.ErrorJSON(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return "", err
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, handlers.BodyMaxSize) // limit request body size
+	r.Body = http.MaxBytesReader(w, r.Body, util.BodyMaxSize) // limit request body size
 
 	// Read request body into buffer
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Println(err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return "", err
 	}
 
@@ -46,7 +51,7 @@ func getAccountIDfromBody(w http.ResponseWriter, r *http.Request) (string, error
 	// Unmarshal json
 	if err := json.Unmarshal(bodyBytes, &b); err != nil {
 		log.Println(err)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		util.ErrorJSON(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return "", err
 	}
 
@@ -55,10 +60,20 @@ func getAccountIDfromBody(w http.ResponseWriter, r *http.Request) (string, error
 	if !ok {
 		err := errors.New("request body missing required field \"account_id\"")
 		log.Println(err)
-		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
+		util.ErrorJSON(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 		return "", err
 	}
 	accountID := string(accountIDraw)
+	accountID = strings.TrimPrefix(accountID, "\"")
+	accountID = strings.TrimSuffix(accountID, "\"")
+
+	// Quick and dirty check that accountID is 36 character string.
+	// TODO: change this to a regex for the uuid format
+	if len(accountID) != 36 {
+		log.Println(errBadAccountID)
+		util.ErrorJSON(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return "", errBadAccountID
+	}
 
 	// Now that accountID is extracted, restore request body to its original state so that next can use it
 	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
@@ -76,32 +91,46 @@ func (srv *Server) WithAPIkeyAuth(next http.Handler) http.Handler {
 		if err != nil {
 			// Could not get APIkey, return 401
 			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			util.ErrorJSON(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
 
 		// Get accoutID from the request body
 		accountID, err := getAccountIDfromBody(w, r)
 		if err != nil {
+			// getAccountIDfromBody takes care of error handling and logging, return immediately
 			return
 		}
 
 		// Get corresponding row from the apikey table in the database
 		apikey, err := srv.db.GetAPIkey(accountID)
 		if err != nil {
-			log.Println(err)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			log.Printf("could not find apikey for account_id=%v", accountID)
+			// w.WriteHeader(http.StatusForbidden)
+			util.ErrorJSON(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
 
 		// Check that key hashes match
 		if !auth.CheckKeyHash(key, apikey.KeyHash) {
 			log.Printf("recieved invalid api key for account %v", accountID)
-			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			// w.WriteHeader(http.StatusForbidden)
+			util.ErrorJSON(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}
 
 		// Request authorized, call next
+		next.ServeHTTP(w, r)
+	})
+}
+
+// WithAPIHeaders adds security headers to the wrapped handler
+func WithAPIHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Content-Type", "application/json")
+		w.Header().Add("Strict-Transport-Security", "max-age=6307200; includeSubDomains")
+		w.Header().Add("X-Content-Type-Options", "nosniff")
+		w.Header().Add("X-Permitted-Cross-Domain-Policies", "none")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/backend/internal/server/middlewear.go
+++ b/backend/internal/server/middlewear.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/handlers"
+)
+
+func getAPIkey(r *http.Request) (auth.Key, error) {
+	s, err := auth.GetBearerToken(r)
+	return auth.Key(s), err
+}
+
+// getAccountIDfromBody attempts to get the "account_id" field from the *http.Request body without
+// mutating the *http.Request (see https://stackoverflow.com/a/47295689/6277051). Handles http error
+// responses and returns an error if "account_id" field doesn't exist or other error occurs. Caller
+// should return immediately on non-nil error
+func getAccountIDfromBody(w http.ResponseWriter, r *http.Request) (string, error) {
+	// Check that request body exists
+	if r.Body == nil {
+		err := errors.New("request body was nil")
+		log.Println(err)
+		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
+		return "", err
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, handlers.BodyMaxSize) // limit request body size
+
+	// Read request body into buffer
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Println(err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return "", err
+	}
+
+	// A map container to decode the JSON body into
+	b := make(map[string]json.RawMessage)
+
+	// Unmarshal json
+	if err := json.Unmarshal(bodyBytes, &b); err != nil {
+		log.Println(err)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return "", err
+	}
+
+	// Extract account_id
+	accountIDraw, ok := b["account_id"]
+	if !ok {
+		err := errors.New("request body missing required field \"account_id\"")
+		log.Println(err)
+		http.Error(w, http.StatusText(http.StatusUnprocessableEntity), http.StatusUnprocessableEntity)
+		return "", err
+	}
+	accountID := string(accountIDraw)
+
+	// Now that accountID is extracted, restore request body to its original state so that next can use it
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	return accountID, nil
+}
+
+// WithAPIkeyAuth is a middlewear function for protecting handlers for routes that require an API key.
+// APIkey protected requests require that the sender send an API key in the Authorization header, as well
+// as its corresponding account_id field in the request's body.
+func (srv *Server) WithAPIkeyAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Get the api key from the Authorization header
+		key, err := getAPIkey(r)
+		if err != nil {
+			// Could not get APIkey, return 401
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		// Get accoutID from the request body
+		accountID, err := getAccountIDfromBody(w, r)
+		if err != nil {
+			return
+		}
+
+		// Get corresponding row from the apikey table in the database
+		apikey, err := srv.db.GetAPIkey(accountID)
+		if err != nil {
+			log.Println(err)
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		// Check that key hashes match
+		if !auth.CheckKeyHash(key, apikey.KeyHash) {
+			log.Printf("recieved invalid api key for account %v", accountID)
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		// Request authorized, call next
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -49,7 +49,7 @@ func New(cfg Config) (*Server, error) {
 
 	// NOTE: It's important that this handler be registered after the other handlers, or else
 	// all routes return a 404 (at least in development). TODO: figure out why this is the case.
-	spaHandler := handlers.NewSpaHandler("../frontend", "index.html")
+	spaHandler := WithHTMLHeaders(handlers.NewSpaHandler("../frontend", "index.html"))
 	srv.router.PathPrefix("/").Handler(spaHandler)
 
 	return srv, nil

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -38,11 +38,14 @@ func New(cfg Config) (*Server, error) {
 	}
 	srv := &Server{cfg, mux.NewRouter(), auth.NewSessionManager(cfg.SessionTimeout), db}
 
-	loginHandler := handlers.NewLoginHandler(srv.sm, db)
+	loginHandler := WithAPIHeaders(handlers.NewLoginHandler(srv.sm, srv.db))
 	srv.router.Handle("/api/login", loginHandler).Methods("POST")
 
-	logoutHandler := handlers.NewLogoutHandler(srv.sm)
-	srv.router.Handle("/api/logout", srv.sm.WithSessionAuth(logoutHandler)).Methods("DELETE")
+	logoutHandler := WithAPIHeaders(srv.sm.WithSessionAuth(handlers.NewLogoutHandler(srv.sm)))
+	srv.router.Handle("/api/logout", logoutHandler).Methods("DELETE")
+
+	metricsPostHandler := WithAPIHeaders(srv.WithAPIkeyAuth(handlers.NewMetricsPostHandler(srv.db)))
+	srv.router.Handle("/api/metrics", metricsPostHandler).Methods("POST")
 
 	// NOTE: It's important that this handler be registered after the other handlers, or else
 	// all routes return a 404 (at least in development). TODO: figure out why this is the case.


### PR DESCRIPTION
The PR adds the "api/metrics" POST endpoint (to be hit by fakeiot). To do so, I needed to add the `model/apikey.go` `model/metric.go` and `model/user.go` models to the schema, and their corresponding files in `database/` for manipulating them. 

`handlers/metric.go` makes use of these new functions to add users to the database as they come in from the `fakeiot` devices. The `metricsPostHandler` is also wrapped in the `WithAPIkeyAuth` middlewear to ensure the caller is sending a valid api key in Bearer token format via the Authorization header. 

I've also added `WithAPIHeaders` and WithHTMLHeaders` middlewear, and added a new util (which is now in its own package) named `ErrorJSON` which functions like `http.Error` but doesn't rewrite the "Content-Type" header to "text/plain" (which was the source of some major pain in trying to figure out what `fakeiot` was complaining about).

#### To test:
Run
```
docker-compose -f docker-compose-dev.yml up
```
Once the backend is built, the Docker logs should print something along the lines of
```
backend-dev     | 2021/01/16 03:38:34 Created fakeiot test account with account_id=testacct-0000-0000-0000-000000000000, username/pwd=test@goteleport.com, and token=tXOSpmXIyAdycSWAJqRS-YMg4gEMQHSEfXY7MadP68Q=
```

Copy the token (aka API key) from that line (make sure it's the line corresponding to `account_id=testacct-0000-0000-0000-000000000000` and not the other one)

Then, assuming you already have [`fakeiot`](https://github.com/gravitational/fakeiot) installed locally, navigate to the repo in another terminal and run
```
fakeiot --token=$TOKEN_YOU_JUST_COPIED --url="https://localhost:8000/api" --ca-cert=./certs/localhost.crt test
```
and all tests should pass.

You can also run
```
fakeiot --token=$TOKEN_YOU_JUST_COPIED --url="https://localhost:8000/api" --ca-cert=./certs/localhost.crt run --period=5s --freq=0.1s --users=100 --account-id=testacct-0000-0000-0000-000000000000
```
a few times and then manually examine the sqlite database file and see that users are being added to the `user` table (with `is_active` set to false, once you get over 100 users) and metrics are being added to `metric` table.
