### PR TITLE
Metrics get

### DIFF
--- a/backend/internal/handlers/login.go
+++ b/backend/internal/handlers/login.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
 	"github.com/ibeckermayer/teleport-interview/backend/internal/database"
-	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
 	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
 )
 
@@ -30,7 +29,6 @@ type loginRequestBody struct {
 
 type loginResponseBody struct {
 	SessionID auth.SessionID `json:"sessionID"`
-	Plan      model.Plan     `json:"plan"`
 }
 
 // Handles user login
@@ -72,7 +70,7 @@ func (lh *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(loginResponseBody{session.SessionID, session.Account.Plan}); err != nil {
+	if err := json.NewEncoder(w).Encode(loginResponseBody{session.SessionID}); err != nil {
 		log.Println(err)
 		return
 	}

--- a/backend/internal/handlers/metric.go
+++ b/backend/internal/handlers/metric.go
@@ -1,20 +1,23 @@
 package handlers
 
 import (
+	"encoding/json"
 	"log"
 	"net/http"
 	"time"
 
+	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
 	"github.com/ibeckermayer/teleport-interview/backend/internal/database"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
 	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
 )
 
-// MetricsPostHandler handles calls to "api/metrics"
+// MetricsPostHandler handles POST calls to "api/metrics"
 type MetricsPostHandler struct {
 	db *database.Database
 }
 
-// NewMetricsPostHandler creates a new MetricsHandler
+// NewMetricsPostHandler creates a new MetricsPostHandler
 func NewMetricsPostHandler(db *database.Database) *MetricsPostHandler {
 	return &MetricsPostHandler{db}
 }
@@ -52,5 +55,50 @@ func (mph *MetricsPostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			log.Println(err)
 			util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		}
+	}
+}
+
+// MetricsGetHandler handles GET calls to "api/metrics"
+type MetricsGetHandler struct {
+	sm *auth.SessionManager
+	db *database.Database
+}
+
+// NewMetricsGetHandler creates a new MetricsGetHandler
+func NewMetricsGetHandler(sm *auth.SessionManager, db *database.Database) *MetricsGetHandler {
+	return &MetricsGetHandler{sm, db}
+}
+
+type metricsGetResponseBody struct {
+	Plan       model.Plan `json:"plan"`
+	MaxUsers   int        `json:"maxUsers"`
+	TotalUsers int        `json:"totalUsers"`
+}
+
+// Handles "api/metrics" GET requests. Should be wrapped with WithSessionAuth and WithAPIHeaders
+func (mgh *MetricsGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	session, err := mgh.sm.FromContext(r.Context())
+	if err != nil {
+		log.Println(err)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	totalUsers, err := mgh.db.CountUsers(session.Account.AccountID)
+	if err != nil {
+		log.Println(err)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	respBody := metricsGetResponseBody{
+		session.Account.Plan,
+		model.PlanMaxUsers[session.Account.Plan],
+		totalUsers,
+	}
+
+	if err := json.NewEncoder(w).Encode(respBody); err != nil {
+		log.Println(err)
+		return
 	}
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -47,6 +47,9 @@ func New(cfg Config) (*Server, error) {
 	metricsPostHandler := WithAPIHeaders(srv.WithAPIkeyAuth(handlers.NewMetricsPostHandler(srv.db)))
 	srv.router.Handle("/api/metrics", metricsPostHandler).Methods("POST")
 
+	metricsGetHandler := WithAPIHeaders(srv.sm.WithSessionAuth(handlers.NewMetricsGetHandler(srv.sm, srv.db)))
+	srv.router.Handle("/api/metrics", metricsGetHandler).Methods("GET")
+
 	// NOTE: It's important that this handler be registered after the other handlers, or else
 	// all routes return a 404 (at least in development). TODO: figure out why this is the case.
 	spaHandler := WithHTMLHeaders(handlers.NewSpaHandler("../frontend", "index.html"))

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -29,6 +29,7 @@ export default {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
+        ...getBearerTokenHeader(),
       },
       body: JSON.stringify(body),
     });
@@ -41,5 +42,16 @@ export default {
       headers: getBearerTokenHeader(),
     });
     return checkStatus(response);
+  },
+  async get(route) {
+    const response = await fetch(`api${route}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...getBearerTokenHeader(),
+      },
+    });
+    const responseChecked = await checkStatus(response);
+    return parseJSON(responseChecked);
   },
 };

--- a/frontend/src/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/components/Dashboard/Dashboard.jsx
@@ -1,9 +1,42 @@
-import React, { useContext } from 'react';
+/* eslint-disable no-constant-condition */
+import React, { useContext, useState } from 'react';
 import api from '../../api';
 import { StoreContext } from '../../store';
+import { useInterval } from '../../hooks';
 
 function Dashboard() {
   const { setStore } = useContext(StoreContext);
+
+  // TODO: save and restore state to/from localStorage to improve UX on login
+  const [state, setState] = useState({
+    plan: 'FREE', // TODO: make global const
+    maxUsers: 100, // TODO: make global const
+    totalUsers: 0,
+  });
+
+  // Polling function to get a near-continuous stream of metrics for this account
+  const pollMetrics = async () => {
+    try {
+      const newState = await api.get('/metrics');
+      setState(newState);
+    } catch (error) {
+      // if session timeout (in the typical case)
+      if (error.response.status === 401) {
+        // setStore to null to remove the session
+        // <Authenticated> component will redirect the user to login page
+        setStore(null);
+      } else {
+        // TODO send to some error logging service
+        // eslint-disable-next-line no-console
+        console.error(error);
+      }
+    }
+  };
+
+  // Set interval to poll for metrics
+  // TODO: make poll interval a config var
+  useInterval(pollMetrics, 300);
+
   const logout = async e => {
     e.preventDefault();
     try {
@@ -17,6 +50,15 @@ function Dashboard() {
     }
   };
 
+  // Calculates the width for the progress bar based on state and returns
+  // a string with '%' appended for use in a style attribute
+  const progressWidth = () => {
+    const num =
+      state.totalUsers <= state.maxUsers ? state.totalUsers : state.maxUsers;
+    const den = state.maxUsers;
+    return `${(num / den) * 100}%`;
+  };
+
   return (
     <div>
       <header className="top-nav">
@@ -28,30 +70,43 @@ function Dashboard() {
           Logout
         </button>
       </header>
-
-      <div className="alert is-error">
-        You have exceeded the maximum number of users for your account, please
-        upgrade your plan to increaese the limit.
-      </div>
-      <div className="alert is-success">
-        Your account has been upgraded successfully!
-      </div>
-
+      {state.totalUsers > state.maxUsers ? (
+        <div className="alert is-error">
+          You have exceeded the maximum number of users for your account, please
+          upgrade your plan to increase the limit.
+        </div>
+      ) : null}
+      {null ? (
+        <div className="alert is-success">
+          Your account has been upgraded successfully!
+        </div>
+      ) : null}
       <div className="plan">
         <header>Startup Plan - $100/Month</header>
 
         <div className="plan-content">
           <div className="progress-bar">
-            <div style={{ width: '35%' }} className="progress-bar-usage" />
+            <div
+              style={{ width: `${progressWidth()}` }}
+              className="progress-bar-usage"
+            />
           </div>
 
-          <h3>Users: 35/100</h3>
+          <h3>
+            Users:{' '}
+            {state.totalUsers <= state.maxUsers
+              ? state.totalUsers
+              : state.maxUsers}
+            /{state.maxUsers}
+          </h3>
         </div>
 
         <footer>
-          <button className="button is-success" type="button">
-            Upgrade to Enterprise Plan
-          </button>
+          {state.plan === 'FREE' ? (
+            <button className="button is-success" type="button">
+              Upgrade to Enterprise Plan
+            </button>
+          ) : null}
         </footer>
       </div>
     </div>

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -1,0 +1,4 @@
+import useInterval from './useInterval';
+
+// eslint-disable-next-line import/prefer-default-export
+export { useInterval };

--- a/frontend/src/hooks/useInterval.jsx
+++ b/frontend/src/hooks/useInterval.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react';
+
+// See https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+export default function useInterval(callback, delay) {
+  const savedCallback = useRef();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    function tick() {
+      savedCallback.current();
+    }
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+    return null;
+  }, [delay]);
+}


### PR DESCRIPTION
NOTE: setting this to merge into the `metrics` branch temporarily, in order to give an accurate diff while https://github.com/ibeckermayer/teleport-interview/pull/8 is still alive. Should be changed to `master` once https://github.com/ibeckermayer/teleport-interview/pull/8 is merged.

Adds the "api/metrics" GET endpoint on the backend and updates the Dashboard component on the frontend to poll for metrics and update the interface based on what is received.

#### To test
```
docker-compose -f docker-compose-dev.yml up
```

Copy the token from the line that looks like
```
backend-dev     | 2021/01/16 21:54:50 Created fakeiot test account with account_id=testacct-0000-0000-0000-000000000000, username/pwd=test@goteleport.com, and token=_pRmtus88dEg2CGZA5GqQfzydUDu9yxYUkYUCjRC39o=
```

navigate to https://0.0.0.0:8080 and login with username/pwd=`test@goteleport.com`

In another terminal, run
```
export TOKEN=<token_you_just_copied>
fakeiot --token=$TOKEN --url="https://localhost:8000/api" --ca-cert=./certs/localhost.crt run --period=20s --freq=0.1s --users=100 --account-id=testacct-0000-0000-0000-000000000000
```

Navigate back to your browser window and see the interface update in [close to] realtime. Run the `fakeiot` command above until 100+ users have been faked, and see the "maximum users" warning appear.

You can also check that the polling function handles session timeout appropriately by changing `"12h"` in `main.go` to something short like `"3s"`, i.e. 
```go
sessionTimeout := flag.String("sesh", "3s", "A parseable duration string (https://golang.org/pkg/time/#ParseDuration) specifying the absolute timeout value for user sessions")
```

Then log in again and see that after a few seconds, the client receives a 401 and subsequently redirects the user back to the login screen.