### PR TITLE
adding upgrade feature

### DIFF
--- a/backend/internal/auth/sessionmanager.go
+++ b/backend/internal/auth/sessionmanager.go
@@ -70,6 +70,13 @@ func (sm *SessionManager) CreateSession(account model.Account) (Session, error) 
 	return s, nil
 }
 
+// UpdateSession updates a session in the session manager with the new session passed in to it.
+func (sm *SessionManager) UpdateSession(session Session) {
+	sm.mtx.Lock()
+	defer sm.mtx.Unlock()
+	sm.store[session.SessionID] = session
+}
+
 // getSession gets a session by sessionID if it exists and isn't expired, otherwise
 // it returns an empty Session object and a non-nil error
 func (sm *SessionManager) getSession(sid SessionID) (Session, error) {

--- a/backend/internal/database/user.go
+++ b/backend/internal/database/user.go
@@ -30,6 +30,9 @@ func (db *Database) CountUsers(accountID string) (int, error) {
 // whether the new User is active based on if the associated account has reached the
 // user limit on its current plan.
 func (db *Database) CreateUser(userID, accountID string) error {
+	createUserUpgradeAccountLock.Lock()
+	defer createUserUpgradeAccountLock.Unlock()
+
 	account, err := db.GetAccount(accountID)
 	if err != nil {
 		// Could not find account, don't create orphaned user

--- a/backend/internal/handlers/upgrade.go
+++ b/backend/internal/handlers/upgrade.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/ibeckermayer/teleport-interview/backend/internal/auth"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/database"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/model"
+	"github.com/ibeckermayer/teleport-interview/backend/internal/util"
+)
+
+// UpgradeHandler handles calls to "api/upgrade"
+type UpgradeHandler struct {
+	sm *auth.SessionManager
+	db *database.Database
+}
+
+// NewUpgradeHandler creates a new UpgradeHandler
+func NewUpgradeHandler(sm *auth.SessionManager, db *database.Database) *UpgradeHandler {
+	return &UpgradeHandler{sm, db}
+}
+
+type upgradHandlerResponseBody metricsGetResponseBody
+
+// Handles "api/upgrade" calls. Should be wrapped with WithAPIHeaders and WithSessionAuth
+func (uh *UpgradeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	session, err := uh.sm.FromContext(r.Context())
+	if err != nil {
+		log.Println(err)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Upgrade the account and set its excess users to active, grabbing the total number of users in the process
+	totalUsers, err := uh.db.UpgradeAccount(session.Account.AccountID)
+	if err != nil {
+		log.Println(err)
+		util.ErrorJSON(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Update the session in the session manager
+	session.Account.Plan = model.ENTERPRISE
+	uh.sm.UpdateSession(session)
+
+	// Build and send response body
+	respBody := upgradHandlerResponseBody{
+		session.Account.Plan,
+		model.PlanMaxUsers[session.Account.Plan],
+		totalUsers,
+	}
+
+	if err := json.NewEncoder(w).Encode(respBody); err != nil {
+		log.Println(err)
+		return
+	}
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -50,6 +50,9 @@ func New(cfg Config) (*Server, error) {
 	metricsGetHandler := WithAPIHeaders(srv.sm.WithSessionAuth(handlers.NewMetricsGetHandler(srv.sm, srv.db)))
 	srv.router.Handle("/api/metrics", metricsGetHandler).Methods("GET")
 
+	upgradeHandler := WithAPIHeaders(srv.sm.WithSessionAuth(handlers.NewUpgradeHandler(srv.sm, srv.db)))
+	srv.router.Handle("/api/upgrade", upgradeHandler).Methods("PATCH")
+
 	// NOTE: It's important that this handler be registered after the other handlers, or else
 	// all routes return a 404 (at least in development). TODO: figure out why this is the case.
 	spaHandler := WithHTMLHeaders(handlers.NewSpaHandler("../frontend", "index.html"))

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -54,4 +54,15 @@ export default {
     const responseChecked = await checkStatus(response);
     return parseJSON(responseChecked);
   },
+  async patch(route) {
+    const response = await fetch(`api${route}`, {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        ...getBearerTokenHeader(),
+      },
+    });
+    const responseChecked = await checkStatus(response);
+    return parseJSON(responseChecked);
+  },
 };


### PR DESCRIPTION
NOTE: setting this to merge into the `metrics_get` branch temporarily, in order to give a more accurate diff while https://github.com/ibeckermayer/teleport-interview/pull/9 is still alive. Should be changed to master once https://github.com/ibeckermayer/teleport-interview/pull/9 is merged.

This adds the final core feature to the project, a functioning upgrade button. Now if a user clicks the upgrade button, their account will be upgraded to the enterprise plan, all of their previously inactive users will be set to active, and the "successful upgrade" banner will flash onto the screen for 3 seconds as the upgrade button disappears.

On the frontend, this PR completes the full feature set. There are aspects of the UX that are clunky at this point -- the dashboard load can be awkward, with the number of users and existence of the upgrade button taking a small but visible time to initialize. It's possible for the "you've exceeded your limit" and "successful upgrade" banners to stack momentarily, and whether or not a banner is shown determines how high up the screen the progress bar is (it would be smoother if that height was fixed and the banners just showed up in empty space). But for the sake of getting to the unit tests for this project, I'm going to let those go for now.

The backend update is mostly straightforward: I've added an `UpdateSession` method to the `SessionManager` and an `UpgradeHandler` to handle calls to the "/api/upgrade" endpoint.

`database.UpgradeAccount` is novel in this codebase in that I use a transaction to ensure that the account upgrade from FREE to ENTERPRISE _and_ the updating of all that accounts' corresponding inactive users to being active both happen in the upgrade call, in order to ensure the data model doesn't get partially corrupted (i.e. the account is upgraded successfully to ENTERPRISE but the call to upgrade all of its corresponding users to active fails).

One tricky wildcard I believe I've found (based on running the app and examining the database afterwards) is that if a `CreateUser` is called during an `UpgradeAccount` transaction, that user can wind up being created with `is_active` set to `false` (if the account was above its user limit before being upgraded), and not get updated to `true` when the `UpgradeAccount` transaction completes. What I think is happening (but haven't confirmed) is that internally the database is setting up the transactions in-memory based on what was in the database when they were initiated, and then committing them based on that in-memory representation. So if a `CreateUser` runs right after line 34 in `UpgradeAccount`
```go
_, err = tx.Exec("UPDATE user SET is_active=$1 WHERE is_active=$2 AND account_id=$3", true, false, accountID)
// CreateUser executes here, before tx.Commit().
```
that newly minted user isn't included in the UPDATE. To solve this, I've added the `createUserUpgradeAccountLock`. That feels like a bit of a hack, but probably the best I'm going to get to for this project.

#### To test
Test this similarly to https://github.com/ibeckermayer/teleport-interview/pull/9, but this time try clicking the "Upgrade" button.
